### PR TITLE
Reset dev branch to main

### DIFF
--- a/.github/workflows/auto-reset-dev-branch.yml
+++ b/.github/workflows/auto-reset-dev-branch.yml
@@ -1,0 +1,22 @@
+name: Auto-reset dev branch
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  reset-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Reset dev to main
+        run: |
+          git config --global user.name 'GitHub Action'
+          git config --global user.email 'action@github.com'
+          git checkout dev
+          git reset --hard origin/main
+          git push origin dev --force


### PR DESCRIPTION
Adds a GitHub Action to automatically reset the `dev` branch to `main` after any push to `main`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac78334f-c70b-4b4d-987e-bf61a97b6492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac78334f-c70b-4b4d-987e-bf61a97b6492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

